### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
+    @item = Item.order("created_at DESC").includes(:user)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.order("created_at DESC").includes(:user)
+    @items = Item.order('created_at DESC').includes(:user)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @item = Item.order("created_at DESC").includes(:user)
+    @items = Item.order("created_at DESC").includes(:user)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,59 +123,57 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% unless @items.empty? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <%# <div class='sold-out'> %>
+                  <%# <span>Sold Out!!</span> %>
+                <%# </div> %>
+                <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.title %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= DeliveryFee.find(item.delivery_fee_id).name %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% else %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
## What
最終課題のフリマアプリ実装における
- 商品一覧表示機能の実装

## Why
フリマアプリの商品管理機能実装に当たって
- 商品の一覧表示機能を運用可能にするため。

## 動作確認用のGyazoリンク

- 画像が表示されており、画像がリンク切れなどになっていないこと

- 出品した商品の一覧表示ができていること

- 上から、出品された日時が新しい順に表示されること

- 「画像/価格/商品名」の3つの情報について表示できていること
https://gyazo.com/be31b8281247ebffd601ddc8a9c9cc43

- ログアウト（ログイン）状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/3935c7d7ac92c54fb8d06dbaaf018cfa
https://gyazo.com/ebce30ecfbcc370496ab78f7956035a4